### PR TITLE
Add Autotools' required README (link to README.md)

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,1 @@
+README.md


### PR DESCRIPTION
Build automation scripts creates an empty `README` file if one is not present (to pacify `autoreconf`, by GNU Autotools).
This modification creates a link README as a symbolic link to existing `RADME.md`.