### PR TITLE
Fix bug introduced in 974383b2

### DIFF
--- a/src/ttsnake.c
+++ b/src/ttsnake.c
@@ -391,6 +391,7 @@ void advance (char scene[][NROWS][NCOLS])
 		if(head.x == energy_block[i].x && head.y == energy_block[i].y)
 		{
 			block_count += 1;
+			flag = 1;
 			energy_block[i].x = BLOCK_INACTIVE;
 		}
 	}


### PR DESCRIPTION
Snake had stopped increasing in size ever since that commit because the `flag = 1` line was erased in 974383b2