### PR TITLE
Seamlessly execute local and installed program (wrapper script)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
 
- TexTron Snake
- ==============================
-
+ # TexTron Snake
+ 
  TexTron Snake is a very simple ASCII snake game tributed to the classic
  Tron arcade. It was meant to be developed as a collaborative programming
  exercise in a course on Open Source Systems taught to undergraduate CS
  students.
 
- INSTALL
- --------------------------------------------------
-
+ ## INSTALL
 
  If you have obtained the project source from the __version control repository__,
 
@@ -19,25 +16,26 @@
  $ ./autogen.sh
  ```
 
-to boostrap the build configuration scripts `configure`. To that end, you'll 
-need GNU Build System (Autotools) installed. In debian/ubuntu based platforms, 
-you may install required software with
+to boostrap the build configuration script `configure`. To that end, you'll 
+need to have GNU Build System (Autotools) installed. In debian/ubuntu based 
+platforms,  you may install required software with
 
 ```
-sudo apt install automake autoconf
+$ sudo apt install automake autoconf
 ```
 
-On the other hand, if you have either downloaded a __distribution tarball__ or 
-bootstraped the build system as described above, then you should already have 
-the configuration script `configure`. In this case, just execute it
+On the other hand, if you have obtained the software form a __distribution 
+repository__, usually as a tarball, you should already have the  script `configure`.
+
+Either way, locate the file in the root of source directory and execute it
 
 ```
  $ ./configure
 ```
 
-This script shall perform a series of tests to collect data about
-the build platform. If it complains about missing pieces of software,
-install them as needed.
+This script shall perform a series of tests to collect data about the build 
+platform. If it complains about missing pieces of software, install them 
+as needed.
 
 For instance, you'll need `libncurses`, which in debian/ubuntu may be
 installed with
@@ -61,8 +59,8 @@ privileges (sudo) are required to write in those locations.
 
 
 
-Optionally, if you wish to build and install the software under a __different
-location__, for instance, in /tmp/foo
+Optionally, if you wish to install the software under a different location,
+ for instance, in `/tmp/foo`, execute
 
 ```
  $ ./configure --prefix=/tmp/foo
@@ -73,42 +71,47 @@ location__, for instance, in /tmp/foo
 This shall install the software locally, in this case in `/tmp/foo/bin`
 and the data files in `/tmp/share`. 
 
-__NOTES__
+ For more detailed instructions, please, refer to file `INSTALL`
 
- Scene files are installed under` $(prefix)/share/ttsnake`
- and the program always read from there. 
+## EXECUTION
+
+```
+ Usage:  ttsnake [options]
+
+         Options
+         
+	 -h, --help      Displays this information message
+	 -d, --data      Selects a non-default data path
+```
+
+ ## Playing the game
  
- Therefore, you __need to install__ the software (system-wide or locally) 
- in order to properly executed. It will not execute if not installed.
+ The game takes place on a rectangular areana where a snake continuously
+ move in one of the four directions: left, right, up and down --- it never 
+ stops. As the snake moves it looses energy and if all of it is exausted, the
+ snake dies. To recover energy, the snake needs to eat pieces of food which
+ are constantly replaced at random positions. 
 
+Be careful, though. The arena borders are electrified and would kill the snake
+if touched. Morover, mind that the snake is poisonous and it would also die if 
+it accidently bites itself, i.e. if the snake's head crosses its own body (yes, 
+this is weird for snakes, but this is a Tron Snake).
 
- * Detailed instructions: refer to file `INSTALL`
+The game score is the count of eaten blocks until the game is over.
 
- PROGRAM EXECUTION
- --------------------------------------------------
-
- Usage:  ttsnake
-
-
- FUNCTIONALITY
- --------------------------------------------------
-
- The program will load scene files from the scenes directory.
-
- Controls:
+ ### Controls:
 	WASD to control the snake
 	+ decreases the game speed
 	- increases the game speed 
 	q quits
 	r at anytime to restart the game
 
-CONTRIBUTIONS
---------------------------------------------------
+## Contribute to this project
 
-If you wish to contribute to the project, please, read the file
+If you wish to contribute to the project, please, __do__ read the file
 
 ```
-doc/CONTRIB.md
+doc/CONTRIBUTING.md
 ```
 
 which contains important information.

--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,10 @@ dnl Alternative short name used for directories, binary prefixes etc.
 AC_DEFINE(ALT_SHORT_NAME,["ttsnake"],[Define alternative short name.])
 AC_SUBST([alt_short_name],[ttsnake])
 
+AC_DEFINE(BIN_NAME,["ttsnake"],[Define the program binary name.])
+AC_SUBST([bin_name],[ttsnake])
+
+
 dnl Replace missing functions (see also GNUlib)
 
 dnl AC_CONFIG_LIBOBJ_DIR([replace])

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -1,41 +1,107 @@
 # Contributing to this project
 
 This document needs to be properly edited.
+Meanwhile, there follow some essencial notes.
 
-## Meanwhile, these are some essencial notes
+## General information
 
-* This project's development workflow is based on 
-
-
->> GitFlow branching strategy [1]
-
->> Semantiv versionng 2.0.0 release naming scheme [2]
-
-- If you obtain the source from the Version Control Repository [3], you will
-need GNU Build System (aka Autotools) to build the project (note 1)
+TextTron Snake is free software distributed under GNU GPL vr.3. 
+For licensing and author information, please refer to files COPYING 
+and AUTHORS, respectively.
 
 
-- Latest stabe release resides in _main_ branch.
-Pre-release (alpha, beta, release candidates) reside on branch _prerelease_.
 
 
-- Contribution admission policy requires developers to proposed modifications
+## Obtaining the source and building the software
+
+This project's  source code official repository may be found at 
+
+https://github.com/courselab/ttsnake
+
+If you have obtain the source from the Version Control Repository, you will
+need GNU Build System (aka Autotools) to build the project, as described
+in file `README`, in the root of the project tree (really, reade-me). 
+
+Briefly, bootstrap the build system with
+
+```
+$ ./autogen.sh
+```
+
+to create the build configuration script and then build the software with
+
+```
+$ ./configure 
+$ make
+```
+
+After the software is built, the binary may be found in the subdirectiry `src`.
+
+The file 
+
+```
+src/ttsnake
+```
+
+is actually a wrapper script wich invokes the real binary 
+
+```
+src/ttsnake.bin
+```
+
+with appropirate arguments to read data files from the local subdirectory 'scenes'.
+
+In order to install the software,
+
+```
+$ make install
+```
+This command will copy the file `src/ttsnake.bin` to the system binary path, 
+usually `usr/bin` and invoke a install hook to rename it `ttsnake`. The
+installed binary will read data from the system data path, usually `usr/share`.
+
+To install the software in a different location, use 
+
+```
+$ ./configure --prefix=<some-path>
+$ make
+```
+
+More build and install options may be consulted in
+
+```
+$ ./configure --help
+```
+and in the file `INSTALL`, found in the root of the project tree.
+
+## General guidelines
+
+This project's development workflow is based 
+
+* GitFlow branching strategy [1]
+* Semantiv versionng 2.0.0 release naming scheme [2]
+
+Latest stabe release resides in branch `main`, while pre-releases (alpha, 
+beta, release candidates etc.) reside in branch _prerelease_. Late fixes in
+past stabe releases for maintenance, if any, are found in _legacy_ branhces.
+
+Contribution admission policy requires developers to proposed modifications
 as feature branches and submitted them as pull requests, which in turn
 need to be approved by other developers before being merged into the propper 
 branches.
 
+You are strongly encouraged to write your contribution and communicate
+with the developers and contributors community in English, if possible.
+Do not mind at all if your current skills are modest or incipient; no one
+expects otherwise --- your coding skills and willing to help matter more.
+Use a automatic translator if needed. Just don't name variable and 
+functions in a lnauguage other than English.
 
-- If you are a developer and is assinged an issue, and you believe you are not
+If you are a developer and is assinged an issue, and you believe you are not
 able to handle timely, please, try to reasign it to someone else.
 
-
-- Program reads data from installed files. Therefore, if data is modified
-(e.g. scene files), remember to reinstall (note 2) the project with 
-
-```
-make install
-```
-
+If you don't have direct write access to the repository, you may still fork the
+project and send pull requests.
 
 _Code wisdom for this project_
 
@@ -48,15 +114,5 @@ _Code wisdom for this project_
 
 [2] https://semver.org/
 
-[3] https://github.com/courselab/ttsnake
 
-Notes
 
-(1) A distribution repository with tarballs with pre-build configuration
-scripts (does not need Autotools) should be available upon the first
-stable release.
-
-(2) The alternative to it would be to have a wrapper script in `src` which
-would invoke the binary with some command line option choosing a different
-data path, while the install rule would install the plain binary. This is
-left for future enhancements if ever wished.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,12 +21,26 @@ AM_CPPFLAGS = @CPP_FLAGS@ -DDATADIR=\"@datarootdir@\" -DBINDIR=\"@bindir@\"
 AM_CFLAGS =   @C_FLAGS@ 
 AM_LDFLAGS =  @LD_FLAGS@   
 
-bin_PROGRAMS = ttsnake 
+bin_PROGRAMS = ttsnake.bin 
 
-ttsnake_SOURCES = ttsnake.c utils.c  utils.h 
+ttsnake_bin_SOURCES = ttsnake.c utils.c  utils.h 
 
-ttsnake_CC = @PTHREAD_CC@
-ttsnake_CFLAGS = @PTHREAD_CFLAGS@ 
-ttsnake_LDADD = -lncurses $(LIBOBJS) @PTHREAD_LIBS@ 
+ttsnake_bin_CC = @PTHREAD_CC@
+ttsnake_bin_CFLAGS = @PTHREAD_CFLAGS@ 
+ttsnake_bin_LDADD = -lncurses $(LIBOBJS) @PTHREAD_LIBS@ 
 
+bin_SCRIPTS = ttsnake
 
+ttsnake: ttsnake.sh
+	cp $< $@
+
+clean-local:
+	rm -f ttsnake
+
+install-exec-hook: 
+	cd $(DESTDIR)/$(bindir) && mv ttsnake.bin ttsnake
+
+uninstall-hook:
+	rm -f $(DESTDIR)/$(bindir)/ttsnake
+
+EXTRA_DIST = ttsnake.sh

--- a/src/ttsnake.c
+++ b/src/ttsnake.c
@@ -666,13 +666,14 @@ int main(int argc, char **argv)
 
   /* Initializes program options struct */
   const struct option stoptions[] = {
-      {"customDataDir", required_argument, 0, 'd'},
-      {"help", no_argument, 0, 'h'}};
+      {"data", required_argument, 0, 'd'},
+      {"help", no_argument, 0, 'h'},
+      {"version", no_argument, 0, 'v'}};
 
   char currOpt;
 
   /* Handles options passed as arguments */
-  while ((currOpt = (getopt_long(argc, argv, "d:h", stoptions, NULL))) != -1)
+  while ((currOpt = (getopt_long(argc, argv, "d:h:v", stoptions, NULL))) != -1)
   {
     switch (currOpt)
     {
@@ -683,12 +684,17 @@ int main(int argc, char **argv)
       break;
     case 'h':
       free(curr_data_dir);
-      show_help(argv[0], false);
+      show_help(false);
+      break;
+
+    case 'v':
+      printf (PACKAGE_STRING "\n");
+      exit (EXIT_SUCCESS);
       break;
 
     default:
       free(curr_data_dir);
-      show_help(argv[0], true);
+      show_help(true);
     }
   }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/time.h>
+#include "../config.h"
 
 /* Subtract the ‘struct timeval’ values X and Y, storing the result in RESULT.
    Return 1 if the difference is negative, otherwise 0. 
@@ -55,11 +56,13 @@ timeval_subtract (struct timeval *result, struct timeval *x, struct timeval *y)
 
 /* Shows help screen. Exit code is -1 if isError is set to true */
 
-void show_help(char *program_name, char isError) {
+void show_help(char isError) {
 
     fprintf(isError? stderr : stdout, "\
-[usage] %s [options]\n\
-  -h, --help          Display this information.\n\
-  -d, --customDataDir Sets the data directory. (Default is {install dir}/share/ttsnake)\n", program_name) ;
+Usage: " BIN_NAME " [options]\n\n\
+  Options\n\n\
+  -h, --help       Display this information message.\n\
+  -d, --data       Selects a non-default data path\n\
+  -v, --version    Outputs the program version\n") ;
     exit(isError?-1:0) ;
 } 

--- a/src/utils.h
+++ b/src/utils.h
@@ -44,6 +44,6 @@ timeval_subtract (struct timeval *result, struct timeval *x, struct timeval *y);
 
 /* Shows help screen. Exit code is -1 if isError is set to true */
 
-void show_help(char *program_name, char isError);
+void show_help(char isError);
 
 #endif /* UTILS_H */


### PR DESCRIPTION
__1)__ Taking advantage of #54 by @rolimans, this patch modifies the build scripts to allow for executing the program both from the project tree (uninstalled) and from the installed patch, seamlessly. It removes the necessity of either installing the software or evoking it with different options to read data from non-default path. 

This modification causes `make` to produce a shell script 

```
src/ttsnake
```

which, in turn, evokes the real binary 

```
src/ttnsake.bin -d scenes
```

to read data from the project (local) data files.

When the software is installed

```
make install
```

copies the real binary to `$(prefix)/bin` and rename it to `ttsnake`

Documentation in `README.md` and `doc/CONTRIBUTING.md` have been completed reformulated to reflect the changes.

__2)__ Added an option to show program version

__3)__ In `show_help()`, the use of `argv[0]` to print program name works as long as it's not called with a explicit path. This patch also replaces the use `argv` with a new `config.h` macro `BIN_NAME` defined at compilation time.
