### PR TITLE
Feature/window size

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -27,7 +27,7 @@ ttsnake_bin_SOURCES = ttsnake.c utils.c  utils.h
 
 ttsnake_bin_CC = @PTHREAD_CC@
 ttsnake_bin_CFLAGS = @PTHREAD_CFLAGS@ 
-ttsnake_bin_LDADD = -lncurses $(LIBOBJS) @PTHREAD_LIBS@ 
+ttsnake_bin_LDADD = -lncurses -lm $(LIBOBJS) @PTHREAD_LIBS@ 
 
 bin_SCRIPTS = ttsnake
 

--- a/src/ttsnake.c
+++ b/src/ttsnake.c
@@ -28,6 +28,7 @@
 #include <ncurses.h>
 #include <config.h>
 #include <getopt.h>
+#include <math.h>
 
 #include "utils.h"
 
@@ -408,7 +409,7 @@ void init_game (scene_t* scene)
   srand(time(NULL));
   /*Set initial score and blocks collected 0 */
   block_count = 0;
-  snake.energy = 20;
+  snake.energy = (NCOLS + NROWS);
   snake.head.x = 0;
   snake.head.y = 0;
   snake.direction = right;
@@ -512,10 +513,9 @@ void advance (scene_t* scene)
 			break;
 	}
 
-	/* Lose energy when necessary */
-	if(snake.lastdirection != snake.direction && player_lost == 0){
-      snake.energy--;
-	}
+	/* Lose energy at every step */
+	if(player_lost == 0)
+    	snake.energy--;
 
 	snake.lastdirection = snake.direction;
 
@@ -527,7 +527,7 @@ void advance (scene_t* scene)
 			block_count += 1;
 			flag = 1;
 			energy_block[i].x = BLOCK_INACTIVE;
-      snake.energy+= 10;
+			snake.energy += (NCOLS + NROWS) / 2 * (sqrt(2) / sqrt(max_energy_blocks + 1));
 			more_snacks();
 		}
 	}
@@ -537,7 +537,7 @@ void advance (scene_t* scene)
   if(   head.x <= 0 || head.x >= NCOLS - 1
      || head.y <= 0 || head.y >= NROWS - 1
      || scene[0][head.y][head.x] == SNAKE_BODY
-     || snake.energy == 0)
+     || snake.energy <= 0)
   {
       player_lost = 1;
       return;

--- a/src/ttsnake.c
+++ b/src/ttsnake.c
@@ -28,6 +28,7 @@
 #include <ncurses.h>
 #include <config.h>
 #include <getopt.h>
+#include <math.h>
 
 #include "utils.h"
 
@@ -35,8 +36,7 @@
 
 #define N_GAME_SCENES  4	/* Number of frames of the gamepay scnene. */
 
-#define NCOLS 90		/* Number of columns of the scene. */
-#define NROWS 40		/* Number of rows of the scene. */
+#define LOWER_PANEL_ROWS 6 /* Rows occupied by the lower panel showing score, energy etc */
 
 #define BLANK ' '		/* Blank-screen character. */
 
@@ -64,6 +64,8 @@ struct timeval beginning,	/* Time when game started. */
   elapsed_total,		/* Elapsed time since game baginning. */
   elapsed_pause;		/* Elapsed time total when the player press pause. */
 
+int NROWS; /* Number of rows in the game board */
+int NCOLS; /* Number of cols in the game board */
 
 int movie_delay;		/* How long between move scenes scenes. */
 int game_delay;			/* How long between game scenes. */
@@ -83,6 +85,7 @@ int which_setting; /* Which setting the player is currently configuring */
 
 int block_count; 		/*Number of energy blocks collected */
 
+WINDOW *main_window;
 
 /* SIGINT handler. The variable go_on controls the main loop. */
 
@@ -131,7 +134,7 @@ struct
 
 /* All chars of one single scene. */
 
-typedef char scene_t[NROWS][NCOLS];
+typedef char scene_t[40][90]; /* Maximum values. TODO: allocate dyamically */
 
 /* Count how many scene files exist in the given directory and returns this number one.
    Complexity: O(log(n)) */
@@ -306,15 +309,16 @@ int readscenes (char *dir, char *data_dir, scene_t** scene, int nscenes)
 void draw (scene_t* scene, int number)
 {
   int i, j;
+
+  wmove(main_window, 0, 0);
   for (i=0; i<NROWS; i++)
     {
       for (j=0; j<NCOLS; j++)
 	{
-	  putchar (scene[number][i][j]);
+	  waddch(main_window, scene[number][i][j]);
 	}
-      putchar ('\n');
-      putchar ('\r');
     }
+  wrefresh(main_window);
 }
 
 #define BLOCK_INACTIVE -1
@@ -352,19 +356,19 @@ void showscene (scene_t* scene, int number, int menu)
 
   if (menu)
     {
-      printf ("Elapsed: %5ds, fps=%5.2f\r\n", /* CR-LF because of ncurses. */
+      wprintw (main_window, "Elapsed: %5ds, fps=%5.2f\n", /* CR-LF because of ncurses. */
 	      (int) elapsed_total.tv_sec, fps);
       /*Add to the menu score and blocks collected */	  
-      printf ("Score: %.d\r\n", block_count);
-      printf ("Energy: %d\r\n", snake.energy); 
+      wprintw (main_window, "Score: %.d\n", block_count);
+      wprintw (main_window, "Energy: %d\n", snake.energy); 
       for(i = 0; i < snake.energy; i++){
 	    if(i % ((MAX_SNAKE_ENERGY/100)*5) == 0){ /*prints one bar for every 5% energy left*/
-	   	 printf("|");
+	   	 wprintw(main_window, "|");
 	    }	 
       }
-      printf("\n");
-      printf ("Controls: q: quit | r: restart | WASD: move the snake | +/-: change game speed\r\n");
-      printf ("          h: help & settings | p: pause game\r\n");
+      wprintw(main_window, "\n");
+      wprintw (main_window, "Controls: q: quit | r: restart | WASD: move the snake | +/-: change game speed\n");
+      wprintw (main_window, "          h: help & settings | p: pause game\n");
     }
 }
 
@@ -592,8 +596,8 @@ void playmovie (scene_t* scene, int nscenes)
 
   for (k=0; (k < nscenes) && (go_on); k++)
     {
-      clear ();			               /* Clear screen.    */
-      refresh ();			       /* Refresh screen.  */
+      wclear (main_window);			               /* Clear screen.    */
+      wrefresh (main_window);			       /* Refresh screen.  */
       showscene (scene, k, 0);                 /* Show k-th scene .*/
       how_long.tv_nsec = (movie_delay) * 1e3;  /* Compute delay. */
       nanosleep (&how_long, NULL);	       /* Apply delay. */
@@ -850,6 +854,18 @@ int main(int argc, char **argv)
   noecho();
   curs_set(FALSE);
   cbreak();
+
+  /* Get terminal size */
+  int maxWidth, maxHeight;
+  getmaxyx(stdscr, maxHeight, maxWidth);
+
+  /* Set game board size */
+  NROWS = (int) fmin(maxHeight - LOWER_PANEL_ROWS, 40);
+  NCOLS = (int) fmin(maxWidth, 90);
+
+  main_window = newwin(NROWS + LOWER_PANEL_ROWS, NCOLS,
+          (maxHeight - NROWS - LOWER_PANEL_ROWS) / 2, (maxWidth - NCOLS) / 2);
+  wrefresh(main_window);
 
   /* Default values. */
 


### PR DESCRIPTION
The program now detects the user's terminal size, and adapts to it.

I don't suggest this for the 0.1.0 release as it introduces a bunch of other things that we have to deal with.

# Problems (candidates of new issues)

1. The files under `scenes/` are all images with fixed size of 90x40
    1. The maximum NROW and NCOL must thus be 40 and 90, respectively (I don't think the board should be larger anyway)
    2. The initial animation, the settings and the "YOU LOSE" screen do not appear correctly in smaller terminals.
2. The lower panel showing the score and controls currently requires a width of at least 80 columns, so this is the minimum number of columns I set up.
    1. The players that had problems with the game screen size usually had problems with the number of rows, rather than columns, so I don't think columns would be a problem. Also, there is a common convention that terminals have at least 90 columns, which is all the more reason to believe the minimum of 80 is OK.

Awaiting opinions on how to improve this pull request!

Fix #81
Fix #80